### PR TITLE
windhustler | [H-03] leverageUpReceiver depositing assets to yieldBox can be exploited CU-86dtgnh5x

### DIFF
--- a/contracts/Balancer.sol
+++ b/contracts/Balancer.sol
@@ -248,8 +248,7 @@ contract Balancer is Ownable {
         if (connectedOFTs[_srcOft][_dstChainId].rebalanceable > 0) {
             revert AlreadyInitialized();
         }
-        bool isNative = ITOFT(_srcOft).erc20() == address(0);
-        if (!isNative && _ercData.length == 0) revert PoolInfoRequired();
+        if (_ercData.length == 0) revert PoolInfoRequired();
 
         (uint256 _srcPoolId, uint256 _dstPoolId) = abi.decode(_ercData, (uint256, uint256));
 


### PR DESCRIPTION
patch(`Balancer.sol`): Require `poolId` for native TOFTs as well [`86dtgnh5m`]

- Updated `_ercData.length == 0` check to be valid for all TOFTs type

`GT_05-12-chore_require_poolid_for_all_cases_balancer`