### PR TITLE
windhustler | [M-05] Withdrawing to other chain when exercising options won’t work as expected, leading to DoS CU-86dtgq4c4

### DIFF
--- a/contracts/tOFT/modules/TOFTOptionsReceiverModule.sol
+++ b/contracts/tOFT/modules/TOFTOptionsReceiverModule.sol
@@ -2,10 +2,7 @@
 pragma solidity 0.8.22;
 
 // LZ
-import {
-    MessagingReceipt, OFTReceipt, SendParam
-} from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/interfaces/IOFT.sol";
-import {IOAppMsgInspector} from "@layerzerolabs/lz-evm-oapp-v2/contracts/oapp/interfaces/IOAppMsgInspector.sol";
+import {SendParam} from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/interfaces/IOFT.sol";
 import {OFTMsgCodec} from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/libs/OFTMsgCodec.sol";
 
 // External
@@ -25,6 +22,7 @@ import {
     ITapiocaOptionBroker, IExerciseOptionsData
 } from "tapioca-periph/interfaces/tap-token/ITapiocaOptionBroker.sol";
 import {TOFTInitStruct, ExerciseOptionsMsg, LZSendParam} from "tapioca-periph/interfaces/oft/ITOFT.sol";
+import {IOftSender} from "tapioca-periph/interfaces/oft/IOftSender.sol";
 import {SafeApprove} from "tapioca-periph/libraries/SafeApprove.sol";
 import {TOFTMsgCodec} from "../libraries/TOFTMsgCodec.sol";
 import {BaseTOFT} from "../BaseTOFT.sol";
@@ -232,7 +230,7 @@ contract TOFTOptionsReceiverModule is BaseTOFT {
 
             msg_.lzSendParams.sendParam = _send;
 
-            _sendPacket(msg_.lzSendParams, "", srcChainSender);
+            IOftSender(tapOft).sendPacket{value: msg.value}(msg_.lzSendParams, "");
 
             // Refund extra amounts
             if (tapBalance - amountToSend > 0) {
@@ -249,62 +247,6 @@ contract TOFTOptionsReceiverModule is BaseTOFT {
             if (!getCluster().isWhitelisted(0, _addr)) {
                 revert TOFTOptionsReceiverModule_NotAuthorized(_addr);
             }
-        }
-    }
-
-    function _sendPacket(LZSendParam memory _lzSendParam, bytes memory _composeMsg, address _srcChainSender)
-        private
-        returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt)
-    {
-        /// @dev Applies the token transfers regarding this send() operation.
-        // - amountDebitedLD is the amount in local decimals that was ACTUALLY debited from the sender.
-        // - amountToCreditLD is the amount in local decimals that will be credited to the recipient on the remote OFT instance.
-        (uint256 amountDebitedLD, uint256 amountToCreditLD) = _debit(
-            msg.sender,
-            _lzSendParam.sendParam.amountLD,
-            _lzSendParam.sendParam.minAmountLD,
-            _lzSendParam.sendParam.dstEid
-        );
-
-        /// @dev Builds the options and OFT message to quote in the endpoint.
-        (bytes memory message, bytes memory options) = _buildOFTMsgAndOptionsMemory(
-            _lzSendParam.sendParam, _lzSendParam.extraOptions, _composeMsg, amountToCreditLD, _srcChainSender
-        );
-
-        /// @dev Sends the message to the LayerZero endpoint and returns the LayerZero msg receipt.
-        msgReceipt =
-            _lzSend(_lzSendParam.sendParam.dstEid, message, options, _lzSendParam.fee, _lzSendParam.refundAddress);
-        /// @dev Formulate the OFT receipt.
-        oftReceipt = OFTReceipt(amountDebitedLD, amountToCreditLD);
-
-        emit OFTSent(msgReceipt.guid, _lzSendParam.sendParam.dstEid, msg.sender, amountDebitedLD, amountToCreditLD);
-    }
-    /**
-     * @dev For details about this function, check `BaseTapiocaOmnichainEngine._buildOFTMsgAndOptions()`.
-     * @dev !!!! IMPORTANT !!!! The differences are:
-     *      - memory instead of calldata for parameters.
-     *      - `_msgSender` is used instead of using context `msg.sender`, to preserve context of the OFT call and use `msg.sender` of the source chain.
-     *      - Does NOT combine options, make sure to pass valid options to cover gas costs/value transfers.
-     */
-
-    function _buildOFTMsgAndOptionsMemory(
-        SendParam memory _sendParam,
-        bytes memory _extraOptions,
-        bytes memory _composeMsg,
-        uint256 _amountToCreditLD,
-        address _msgSender
-    ) private view returns (bytes memory message, bytes memory options) {
-        bool hasCompose = _composeMsg.length > 0;
-
-        message = hasCompose
-            ? abi.encodePacked(
-                _sendParam.to, _toSD(_amountToCreditLD), OFTMsgCodec.addressToBytes32(_msgSender), _composeMsg
-            )
-            : abi.encodePacked(_sendParam.to, _toSD(_amountToCreditLD));
-        options = _extraOptions;
-
-        if (msgInspector != address(0)) {
-            IOAppMsgInspector(msgInspector).inspect(message, options);
         }
     }
 }


### PR DESCRIPTION
patch(`TOFTOptionsReceiverModule`): Use the right contract when sending token to another chain [`86dtgq4c4`]

- Use `IToftSender(tapToken).sendPacket` instead of sending the wrong asset over chain 
- Removed unused private `_sendPacket` method

`GT_05-13-chore_fixed_toftoptionsreceivermodule_sendpacket`