### PR TITLE
windhustler | [H-03] leverageUpReceiver depositing assets to yieldBox can be exploited CU-86dtgnh5x

### DIFF
--- a/contracts/tOFT/modules/TOFTMarketReceiverModule.sol
+++ b/contracts/tOFT/modules/TOFTMarketReceiverModule.sol
@@ -50,6 +50,7 @@ contract TOFTMarketReceiverModule is BaseTOFT {
     using SafeCast for uint256;
 
     error TOFTMarketReceiverModule_NotAuthorized(address invalidAddress);
+    error TOFTMarketReceiverModule_AmountNotValid();
 
     event BorrowReceived(
         address indexed user, address indexed market, uint256 indexed amount, bool deposit, bool withdraw
@@ -155,7 +156,6 @@ contract TOFTMarketReceiverModule is BaseTOFT {
     }
 
     function _validateLeverageUpReceiver(LeverageUpActionMsg memory msg_, address srcChainSender) private returns (LeverageUpActionMsg memory) {
-
         _checkWhitelistStatus(msg_.market);
         _checkWhitelistStatus(msg_.marketHelper);
 
@@ -164,6 +164,7 @@ contract TOFTMarketReceiverModule is BaseTOFT {
             msg_.supplyAmount = _toLD(msg_.supplyAmount.toUint64());
         }
 
+        if (msg_.borrowAmount == 0) revert TOFTMarketReceiverModule_AmountNotValid();
         _validateAndSpendAllowance(msg_.user, srcChainSender, msg_.borrowAmount);
 
         return msg_;
@@ -188,6 +189,7 @@ contract TOFTMarketReceiverModule is BaseTOFT {
         msg_.borrowParams.amount = _toLD(msg_.borrowParams.amount.toUint64());
         msg_.borrowParams.borrowAmount = _toLD(msg_.borrowParams.borrowAmount.toUint64());
 
+        if (msg_.borrowParams.amount == 0) revert TOFTMarketReceiverModule_AmountNotValid();
         _validateAndSpendAllowance(msg_.user, srcChainSender, msg_.borrowParams.amount);
 
         return msg_;
@@ -223,6 +225,7 @@ contract TOFTMarketReceiverModule is BaseTOFT {
 
         msg_.removeParams.amount = _toLD(msg_.removeParams.amount.toUint64());
 
+        if (msg_.removeParams.amount == 0) revert TOFTMarketReceiverModule_AmountNotValid();
         _validateAndSpendAllowance(msg_.user, srcChainSender, msg_.removeParams.amount);
         
         return msg_;

--- a/contracts/tOFT/modules/TOFTMarketReceiverModule.sol
+++ b/contracts/tOFT/modules/TOFTMarketReceiverModule.sol
@@ -189,8 +189,9 @@ contract TOFTMarketReceiverModule is BaseTOFT {
         msg_.borrowParams.amount = _toLD(msg_.borrowParams.amount.toUint64());
         msg_.borrowParams.borrowAmount = _toLD(msg_.borrowParams.borrowAmount.toUint64());
 
-        if (msg_.borrowParams.amount == 0) revert TOFTMarketReceiverModule_AmountNotValid();
-        _validateAndSpendAllowance(msg_.user, srcChainSender, msg_.borrowParams.amount);
+        if (msg_.borrowParams.deposit) {
+            _validateAndSpendAllowance(msg_.user, srcChainSender, msg_.borrowParams.amount);
+        }
 
         return msg_;
     }

--- a/contracts/tOFT/modules/TOFTOptionsReceiverModule.sol
+++ b/contracts/tOFT/modules/TOFTOptionsReceiverModule.sol
@@ -141,7 +141,7 @@ contract TOFTOptionsReceiverModule is BaseTOFT {
         /**
         * @dev retrieve exercised amount
         */
-        _withdrawExercised(msg_, srcChainSender);
+        _withdrawExercised(msg_);
 
         emit ExerciseOptionsReceived(
             msg_.optionsData.from, msg_.optionsData.target, msg_.optionsData.oTAPTokenID, msg_.optionsData.paymentTokenAmount
@@ -156,14 +156,16 @@ contract TOFTOptionsReceiverModule is BaseTOFT {
             if (msg_.lockData.amount > 0) {
                 msg_.lockData.amount = _toLD(uint256(msg_.lockData.amount).toUint64()).toUint128();
             }
-            if (msg_.lockData.fraction > 0) msg_.lockData.fraction = _toLD(msg_.lockData.fraction.toUint64());
+            if (msg_.lockData.fraction > 0) {
+                msg_.lockData.fraction = _toLD(msg_.lockData.fraction.toUint64());
+                _validateAndSpendAllowance(msg_.user, srcChainSender, msg_.lockData.fraction);
+            }
         }
 
         if (msg_.participateData.participate) {
             _checkWhitelistStatus(msg_.participateData.target);
         }
 
-        _validateAndSpendAllowance(msg_.user, srcChainSender, msg_.lockData.fraction);
 
         return msg_;
     }
@@ -214,7 +216,7 @@ contract TOFTOptionsReceiverModule is BaseTOFT {
         }
     }
 
-    function _withdrawExercised(ExerciseOptionsMsg memory msg_, address srcChainSender) private {
+    function _withdrawExercised(ExerciseOptionsMsg memory msg_) private {
         SendParam memory _send = msg_.lzSendParams.sendParam;
 
         address tapOft = ITapiocaOptionBroker(msg_.optionsData.target).tapOFT();


### PR DESCRIPTION
patch(`Receivers allowance validation`): Use `validateAndSpend` only when arguments are non-optional [`86dtgnh5x`]

- Whenever arguments are non-optional, check if the allowance value is not 0, so the `validateAndSpend` won't check on a 0 amount
- Whenever arguments are optional, skip validation if argument was not provided 

`GT_05-14-chore_fixed_validateandspend_checks`