### PR TITLE
Remove the Pearlmit code from TOE transferFrom `CU-86dtj04d9`

### DIFF
--- a/contracts/tOFT/TOFT.sol
+++ b/contracts/tOFT/TOFT.sol
@@ -94,14 +94,6 @@ contract TOFT is BaseTOFT, ReentrancyGuard, ERC20Permit {
 
     receive() external payable {}
 
-    function transferFrom(address from, address to, uint256 value)
-        public
-        override(BaseTapiocaOmnichainEngine, ERC20)
-        returns (bool)
-    {
-        return BaseTapiocaOmnichainEngine.transferFrom(from, to, value);
-    }
-
     /**
      * @dev Slightly modified version of the OFT _lzReceive() operation.
      * The composed message is sent to `address(this)` instead of `toAddress`.

--- a/contracts/tOFT/mTOFT.sol
+++ b/contracts/tOFT/mTOFT.sol
@@ -131,14 +131,6 @@ contract mTOFT is BaseTOFT, ReentrancyGuard, ERC20Permit, IStargateReceiver {
 
     receive() external payable {}
 
-    function transferFrom(address from, address to, uint256 value)
-        public
-        override(BaseTapiocaOmnichainEngine, ERC20)
-        returns (bool)
-    {
-        return BaseTapiocaOmnichainEngine.transferFrom(from, to, value);
-    }
-
     /**
      * @dev Slightly modified version of the OFT _lzReceive() operation.
      * The composed message is sent to `address(this)` instead of `toAddress`.


### PR DESCRIPTION
fix(`TOFT/mTOFT`): Removed `transferFrom()` `TOE` override [`86dtj04d9`]
- Checked out `periph` submodule to `GT_86dtj04d9_Remove-the-Pearlmit-code-from-TOE-transferFrom`