### PR TITLE
Remove redundant approval on `BaseTOFT._wrap()` and only use `Pearlmit` one `CU-86dtmkgk4`

### DIFF
--- a/contracts/tOFT/BaseTOFT.sol
+++ b/contracts/tOFT/BaseTOFT.sol
@@ -84,7 +84,8 @@ abstract contract BaseTOFT is
     }
 
     function _wrap(address _fromAddress, address _toAddress, uint256 _amount, uint256 _feeAmount) internal virtual {
-        if (_fromAddress != msg.sender) {
+        // Check internal allowance only if not the same address
+        if (_toAddress != _fromAddress) {
             if (allowance(_fromAddress, msg.sender) < _amount) {
                 revert TOFT_AllowanceNotValid();
             }


### PR DESCRIPTION
patch(`BaseTOFT`): Updated allowance check on `_wrap` to only check internal allowance if `_to` is different than `_from` [`86dtmkgk4`]